### PR TITLE
fix(security): [DEVOP-8410] upgrade and pin 3rd party actions in terraform-release-main

### DIFF
--- a/.github/workflows/terraform-release-main.yml
+++ b/.github/workflows/terraform-release-main.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: "recursive"
           token: ${{ secrets.ENGINEERING_GITHUB_PERSONAL_ACCESS_TOKEN }}
       - name: Set up Terraform
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
       - name: Terraform Format
@@ -37,4 +37,3 @@ jobs:
         id: plan
         run: terraform plan -no-color
         continue-on-error: true
-


### PR DESCRIPTION
### Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* `.github/workflows/terraform-release-main.yml` still referenced two actions by mutable tag. Both are upgraded to the current major and pinned to a SHA, generated with [`actions-up`](https://github.com/azat-io/actions-up):

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | `@v2` | `@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` |
| `hashicorp/setup-terraform` | `@v1` | `@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1` |

* The `setup-terraform` SHA is the same one already used by `workflow-templates/public-terratest.yaml` in honestbank/.github, so this brings the file onto the org standard rather than pinning a bespoke version.
* The pre-commit `end-of-file-fixer` hook also removed a trailing blank line in the same file.

**Why this file was missed.** Every other workflow here is already pinned, because they are all delivered by the file sync from `honestbank/.github` and those templates are pinned. `terraform-release-main.yml` is the only workflow in this repo **not** under sync management.

**Scope.** `actions-up` also offered updates to `checkov.yaml`, `repository-secrets-check.yaml`, `terraform.yaml`, `terratest.yaml` and `trivy.yaml`. Those were deliberately reverted — all five are sync-managed, so repo-local edits are overwritten on the next sync. If we want those bumped, it should happen in the templates in honestbank/.github so every public repo gets it.

> [!IMPORTANT]
> This workflow triggers only on `push` to `main`, so **PR CI does not exercise it**. The `v1 → v4` setup-terraform and `v2 → v7` checkout jumps will first run at merge time. The step inputs in use (`submodules`, `token`, `cli_config_credentials_token`) are all still supported in the target majors, but worth watching the first post-merge release run.

**Replaces #21 and #22.** Both were Aikido autofix PRs for this same "3rd party GitHub Actions should be pinned" finding and both were in conflict. Between them they added `repository-secrets-check.yaml` and re-pinned `semantic-pr.yaml`, `terraform.yaml` and `terratest.yaml` — all already present and pinned on `main` via the sync. The only item neither fully covered was this file: #21 pinned `setup-terraform` but left `actions/checkout@v2` untouched.

> [!NOTE]
> Aikido autofix PRs that edit sync-managed workflow paths will keep going stale, because the next sync overwrites repo-local edits. Worth either excluding those paths from Aikido autofix, or landing such fixes in the honestbank/.github templates.

### Related Tasks & Ticket Links

* DEVOP-8410
